### PR TITLE
recovery.fstab: use /dev/block/by-name symlink for /preload

### DIFF
--- a/recovery.fstab
+++ b/recovery.fstab
@@ -7,7 +7,7 @@
 /efs2          emmc      /dev/block/platform/msm_sdcc.1/by-name/modemst1      flags=backup=1;subpartitionof=/efs1
 /efs3          emmc      /dev/block/platform/msm_sdcc.1/by-name/modemst2      flags=backup=1;subpartitionof=/efs1
 /modem         emmc      /dev/block/platform/msm_sdcc.1/by-name/modem	      flags=backup=1;display="Modem"
-/preload       ext4      /dev/block/mmcblk0p25                                flags=display="Preload";wipeingui;backup=1
+/preload       ext4      /dev/block/platform/msm_sdcc.1/by-name/hidden        flags=display="Preload";wipeingui;backup=1
 /misc          emmc      /dev/block/platform/msm_sdcc.1/by-name/fota          flags=display="Misc"
 
 /external_sd   auto      /dev/block/mmcblk1p1    /dev/block/mmcblk1           flags=display="MicroSD";storage;wipeingui;removable


### PR DESCRIPTION
GT-I9301I (s3ve3g) and GT-I9300I (s3ve3gds) have different partition tables. `/dev/block/mmcblk0p25` on s3ve3g links to the actual preload partition whereas on s3ve3gds it links to the userdata partition. This will lead to data loss in `/data` if the user tries to wipe `/preload` on s3ve3gds devices. To fix this use `/dev/block/platform/msm_sdcc.1/by-name/hidden` symlink for preload partition.